### PR TITLE
50/feat/mainpage info

### DIFF
--- a/backend/src/main/java/com/together/backend/domain/couple/model/entity/Couple.java
+++ b/backend/src/main/java/com/together/backend/domain/couple/model/entity/Couple.java
@@ -23,13 +23,12 @@ public class Couple {
     @Column(name = "partner_user_id")
     private Long partnerUserId; // 상대방 user_id (User 테이블 PK, FK nullable)
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", length = 15)
-    private CoupleStatus status;
+    @Column(name = "is_connected")
+    private Boolean isConnected;
 
     @Column(name = "invited_at")
     private LocalDateTime invitedAt;
 
     @Column(name = "connected_at")
-    private LocalDateTime connectedAt;
+    private LocalDateTime connectedAt; // 연결된 날짜
 }

--- a/backend/src/main/java/com/together/backend/domain/couple/service/CoupleService.java
+++ b/backend/src/main/java/com/together/backend/domain/couple/service/CoupleService.java
@@ -59,10 +59,10 @@ public class CoupleService {
                 .user(user)
                 .partnerUserId(partnerUserId)
                 .connectedAt(LocalDateTime.now())
-                .status(CoupleStatus.CONNECT)
+                .isConnected(true)
                 .build();
 
-        log.info("partner 객체 생성: userEmail = {}, partnerEmail = {}, status = {}", userEmail, partnerEmail, couple.getStatus());
+        log.info("partner 객체 생성: userEmail = {}, partnerEmail = {}, isConnected = {}", userEmail, partnerEmail, couple.getIsConnected());
         coupleRepository.save(couple);
         return new ConnectResponse(couple.getUser().getNickname(), couple.getUser().getProfileImageUrl());
 

--- a/backend/src/main/java/com/together/backend/domain/pill/repository/UserPillRepository.java
+++ b/backend/src/main/java/com/together/backend/domain/pill/repository/UserPillRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface UserPillRepository extends JpaRepository<UserPill, Long> {
     Optional<UserPill> findByUser(User user);
     Optional<UserPill> findByUser_UserId(Long userId);
+    Optional<UserPill> findTopByUserOrderByStartDateDesc(User user); // 가장 최신의 startDate 값 가져오기
 }

--- a/backend/src/main/java/com/together/backend/domain/user/controller/MainPageController.java
+++ b/backend/src/main/java/com/together/backend/domain/user/controller/MainPageController.java
@@ -1,0 +1,70 @@
+package com.together.backend.domain.user.controller;
+
+import com.together.backend.domain.user.model.response.mainpageinfo.PartnerInfoResponse;
+import com.together.backend.domain.user.model.response.mainpageinfo.PillInfoResponse;
+import com.together.backend.domain.user.model.response.mainpageinfo.UserInfoResponse;
+import com.together.backend.domain.user.service.MainPageService;
+import com.together.backend.global.common.BaseResponse;
+import com.together.backend.global.common.BaseResponseStatus;
+import com.together.backend.global.security.oauth2.dto.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/user/home")
+@RequiredArgsConstructor
+public class MainPageController {
+
+    private final MainPageService mainPageService;
+
+    @GetMapping("/user-info")
+    public BaseResponse<UserInfoResponse> getUserInfo(@AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        if (oAuth2User == null) {
+            log.warn("UserInfo 요청: 인증되지 않은 사용자");
+            return new BaseResponse<UserInfoResponse>(BaseResponseStatus.UNAUTHORIZED);
+        }
+        try {
+            String email = oAuth2User.getEmail(); // 유저 이메일
+            UserInfoResponse response = mainPageService.getUserInfo(email);
+            return new BaseResponse<>(BaseResponseStatus.OK, response);
+        } catch (IllegalArgumentException e) {
+            log.error("@@@@{}@@@@",e.getMessage());
+            return new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @GetMapping("/partner-info")
+    public BaseResponse<PartnerInfoResponse> getPartnerInfo(@AuthenticationPrincipal CustomOAuth2User oAuth2User, @RequestParam("email") String email) {
+        if (oAuth2User == null) {
+            log.warn("PartnerInfo 요청: 인증되지 않은 사용자");
+            return new BaseResponse<PartnerInfoResponse>(BaseResponseStatus.UNAUTHORIZED);
+        }
+        try {
+            PartnerInfoResponse response = mainPageService.getPartnerInfo(email);
+            return new BaseResponse<>(BaseResponseStatus.OK,response);
+        } catch (IllegalArgumentException e) {
+            log.error("@@@@{}@@@@",e.getMessage());
+            return new BaseResponse<>(BaseResponseStatus.BAD_REQUEST);
+        }
+
+    }
+
+    @GetMapping("/userpill-info")
+    public BaseResponse<PillInfoResponse> getUserPillInfo(@AuthenticationPrincipal CustomOAuth2User oAuth2User, @RequestParam("email") String email) {
+        if (oAuth2User == null) {
+            log.warn("UserPillInfo 요청: 인증되지 않은 사용자");
+            return new BaseResponse<PillInfoResponse>(BaseResponseStatus.UNAUTHORIZED);
+        }
+        try {
+            PillInfoResponse response = mainPageService.getPillInfo(email);
+            return new BaseResponse<>(BaseResponseStatus.OK,response);
+        } catch (IllegalArgumentException e) {
+            log.error("@@@@{}@@@@",e.getMessage());
+            return new BaseResponse<>(BaseResponseStatus.BAD_REQUEST);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/together/backend/domain/user/model/response/mainpageinfo/PartnerInfoResponse.java
+++ b/backend/src/main/java/com/together/backend/domain/user/model/response/mainpageinfo/PartnerInfoResponse.java
@@ -1,0 +1,12 @@
+package com.together.backend.domain.user.model.response.mainpageinfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PartnerInfoResponse {
+    private String nickname;
+    private boolean connected;
+    private long daysTogether;
+}

--- a/backend/src/main/java/com/together/backend/domain/user/model/response/mainpageinfo/PillInfoResponse.java
+++ b/backend/src/main/java/com/together/backend/domain/user/model/response/mainpageinfo/PillInfoResponse.java
@@ -1,0 +1,10 @@
+package com.together.backend.domain.user.model.response.mainpageinfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PillInfoResponse {
+    private long daysOnPill;
+}

--- a/backend/src/main/java/com/together/backend/domain/user/model/response/mainpageinfo/UserInfoResponse.java
+++ b/backend/src/main/java/com/together/backend/domain/user/model/response/mainpageinfo/UserInfoResponse.java
@@ -1,0 +1,12 @@
+package com.together.backend.domain.user.model.response.mainpageinfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponse {
+    private String email;
+    private String nickname;
+    private String profileImage;
+}

--- a/backend/src/main/java/com/together/backend/domain/user/service/MainPageService.java
+++ b/backend/src/main/java/com/together/backend/domain/user/service/MainPageService.java
@@ -1,0 +1,74 @@
+package com.together.backend.domain.user.service;
+
+import com.together.backend.domain.couple.model.entity.Couple;
+import com.together.backend.domain.couple.repository.CoupleRepository;
+import com.together.backend.domain.pill.model.UserPill;
+import com.together.backend.domain.pill.repository.UserPillRepository;
+import com.together.backend.domain.user.model.entity.User;
+import com.together.backend.domain.user.model.response.mainpageinfo.PartnerInfoResponse;
+import com.together.backend.domain.user.model.response.mainpageinfo.PillInfoResponse;
+import com.together.backend.domain.user.model.response.mainpageinfo.UserInfoResponse;
+import com.together.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+@Slf4j
+@Setter
+@RequiredArgsConstructor
+@Service
+public class MainPageService {
+
+    private final UserRepository userRepository;
+    private final CoupleRepository coupleRepository;
+    private final UserPillRepository userPillRepository;
+
+
+    // 사용자의 이메일 받고 사용자 정보를 전달함
+    public UserInfoResponse getUserInfo(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return new UserInfoResponse(user.getEmail(), user.getNickname(), user.getProfileImageUrl());
+    }
+
+    public PartnerInfoResponse getPartnerInfo(String email) {
+        // 사용자 조회
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Optional<Couple> optCouple = coupleRepository.findByUser(user);
+
+        if (optCouple.isPresent()) {
+            Couple couple = optCouple.get();
+            // 연결이 안됐거나 날짜 없을 때 -> 0일 또는 Null로 처리해야함
+            if (Boolean.TRUE.equals(couple.getIsConnected()) && couple.getConnectedAt() != null) {
+                long daysTogether = ChronoUnit.DAYS.between(couple.getConnectedAt().toLocalDate(), LocalDate.now());
+
+                // 파트너 조회
+                String partnerNickname = userRepository.findByUserId(couple.getPartnerUserId()).map(User::getNickname).orElse("알 수 없음");
+                return new PartnerInfoResponse(partnerNickname,true, daysTogether);
+            } else {
+                //연결 안됨
+                return new PartnerInfoResponse(null, false, 0L);
+            }
+        } else {
+            // 커플 관계 자체가 없을 때
+            return new PartnerInfoResponse(null, false, 0L);
+        }
+
+
+    }
+
+    public PillInfoResponse getPillInfo(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Optional<UserPill> optPill = userPillRepository.findTopByUserOrderByStartDateDesc(user);
+
+        long daysOnPill = optPill.map(pill -> ChronoUnit.DAYS.between(pill.getStartDate(), LocalDate.now())).orElse(0L);
+        return new PillInfoResponse(daysOnPill);
+    }
+
+
+
+}


### PR DESCRIPTION
## 📌 이슈 번호

<!--관련 이슈 언급 -->

- close #50 

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 테스트 하셨나요?
- [x] dev와 충돌 처리 해보셨나요?
- [x] 컨벤션을 지켰나요?
- [x] 리뷰어와 라벨을 지정해주세요


## 🔔 ETC
현재 PillInfo API로직에서 User 테이블의 is_taking_pill의 값이 true/false 여부와 상관없이 UserPill 값이 존재한다면, 
그리고 가장 최근의 시작 기간으로 계산하는 로직이다. 사용자가 복용을 하지 않더라도, 과거에 복용했던 약을 기반으로 날짜를 세는 문제가 있음


해결 방법  true일때만 뜨도록 로직을 추가해야함.

